### PR TITLE
Update for python packaging namespace

### DIFF
--- a/sdk/opendp/README.md
+++ b/sdk/opendp/README.md
@@ -1,0 +1,7 @@
+# Packaging note
+
+- Please do not put an `__init__.py` file in this directory--the `opendp' directory
+- The "opendp" namespace is shared with another package generated from the [whitenoise-core](https://github.com/opendifferentialprivacy/whitenoise-core) repository.
+- For reference, see this python packaging document:
+  - https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages
+    - Note the line: `    # No __init__.py here.`

--- a/sdk/setup.py
+++ b/sdk/setup.py
@@ -1,5 +1,5 @@
 """Setup file for differential privacy package."""
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 import os
 import shutil
 
@@ -40,8 +40,8 @@ setup(
     long_description_content_type="text/x-rst",
     author="opendp-whitenoise",
     license=inline_license,
-    packages=find_packages(exclude=["*.tests"]),
-
+    packages=find_namespace_packages(include=['opendp.*'],
+                                     exclude=["*.tests"]),
     install_requires=DEPENDENCIES,
 
     include_package_data=True,


### PR DESCRIPTION
- Updates for #189 
- Removed the `__init__.py` from the `sdk/opendp` directory to allow packages from whitenoise-core to share the `opendp` namespace 
- Adjusted `setup.py`
