### PR TITLE
Adding pkgutil to share the `opendp.whitenoise` namespace

### DIFF
--- a/sdk/opendp/whitenoise/__init__.py
+++ b/sdk/opendp/whitenoise/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
e.g. Namespace to be shared with packages generated from https://github.com/opendifferentialprivacy/whitenoise-core-python