### PR TITLE
Implement and unit test Black Box Privacy Interface

### DIFF
--- a/tests/sdk/evaluation/dp_blackbox.py
+++ b/tests/sdk/evaluation/dp_blackbox.py
@@ -1,0 +1,24 @@
+from opendp.whitenoise.evaluation.params._privacy_params import PrivacyParams
+from opendp.whitenoise.evaluation.params._eval_params import EvaluatorParams
+from opendp.whitenoise.evaluation.report._report import Report
+from opendp.whitenoise.evaluation.blackbox._base import BlackBoxPrivacyInterface
+
+class DPSampleInterface(BlackBoxPrivacyInterface):
+    """
+    Sample implementation of BlackBoxPrivacy Interface
+    that allows for the library to be stochastically tested by
+    evaluator. 
+    """
+    def prepare(self, analysis: object, privacy_params: PrivacyParams, eval_params: EvaluatorParams):
+        """
+        Load the function (analysis) to be used for acting on the dataset
+        Initialize the privacy params that need to be used by the function
+        for calculating differentially private noise
+        """
+        self.analysis = analysis
+        self.privacy_params = privacy_params
+        self.eval_params = eval_params
+
+    def release(self, dataset: object, actual = False) -> Report:
+        noisy_df = self.analysis.dp_count(dataset, self.privacy_params, self.eval_params)
+        return Report(noisy_df)

--- a/tests/sdk/evaluation/dp_lib.py
+++ b/tests/sdk/evaluation/dp_lib.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import numpy as np
+import math
+
+class DPSampleLibrary:
+    """
+    Sample DP library class implementing DP functions (analysis)
+    """
+    def dp_count(self, df, privacy_params, eval_params):
+        """
+        Returns repeatedly applied differentially private noisy responses while 
+        counting rows of a dataset
+        """
+        delta = 1/(len(df) * math.sqrt(len(df)))
+        sigmacnt = math.sqrt(privacy_params.t)*((math.sqrt(math.log(1/delta)) + math.sqrt(math.log((1/delta)) + eval_params.repeat_count)) / (math.sqrt(2)*eval_params.repeat_count))
+        dp_noise = np.random.normal(0, sigmacnt, eval_params.repeat_count)
+        print(df.shape[0])
+        return pd.DataFrame(df.shape[0] + dp_noise, columns=["Count"])

--- a/tests/sdk/evaluation/dp_lib.py
+++ b/tests/sdk/evaluation/dp_lib.py
@@ -14,5 +14,4 @@ class DPSampleLibrary:
         delta = 1/(len(df) * math.sqrt(len(df)))
         sigmacnt = math.sqrt(privacy_params.t)*((math.sqrt(math.log(1/delta)) + math.sqrt(math.log((1/delta)) + eval_params.repeat_count)) / (math.sqrt(2)*eval_params.repeat_count))
         dp_noise = np.random.normal(0, sigmacnt, eval_params.repeat_count)
-        print(df.shape[0])
         return pd.DataFrame(df.shape[0] + dp_noise, columns=["Count"])

--- a/tests/sdk/evaluation/test_interface.py
+++ b/tests/sdk/evaluation/test_interface.py
@@ -1,0 +1,30 @@
+import logging
+test_logger = logging.getLogger("eval-interface-test-logger")
+from opendp.whitenoise.evaluation.params._privacy_params import PrivacyParams
+from opendp.whitenoise.evaluation.params._eval_params import EvaluatorParams
+from opendp.whitenoise.evaluation.report._report import Report
+from opendp.whitenoise.evaluation.blackbox._base import BlackBoxPrivacyInterface
+from dp_lib import DPSampleLibrary
+from dp_blackbox import DPSampleInterface
+import pandas as pd
+import random
+import pytest
+
+class TestEvalInterface:
+    def test_dp_blackbox(self):
+        logging.getLogger().setLevel(logging.DEBUG)
+        lib = DPSampleLibrary()
+        dv = DPSampleInterface()
+        pp = PrivacyParams(epsilon=1.0)
+        ev = EvaluatorParams(repeat_count=500)
+        df = pd.DataFrame(random.sample(range(1, 1000), 100), columns = ['Usage'])
+
+        # Preparing and releasing from Sample DP library to send noisy results to evaluator
+        dv.prepare(lib, pp, ev)
+        report = dv.release(df)
+        test_logger.debug("Repeated noisy count responses: "  + str(report.res_df.shape[0]))
+        test_logger.debug("Count of Numerical columns in DP repeated response: "  + str(len(report.num_cols)))
+        test_logger.debug("Count of Dimension columns in DP repeated response: "  + str(len(report.dim_cols)))
+        assert(report.res_df.shape[0] == ev.repeat_count)
+        assert(len(report.num_cols) == 1)
+        assert(len(report.dim_cols) == 1)


### PR DESCRIPTION
Sample implementation of a DP library that releases statistics by implementing BlackBoxPrivacyInterface. It takes in the privacy and evaluation params for its analysis and releases noisy responses for evaluator to act on.

Related #216 

**Test Result**
(oss_dp) ankit@ANKIT-DELL:~/privacytoolsproject/whitenoise-system/tests$ pytest -k "test_dp_blackbox"
========test session starts ==============
platform linux -- Python 3.8.0, pytest-5.3.1, py-1.8.0, pluggy-0.13.1
rootdir: /mnt/c/Users/ankitsri/source/code/privacytoolsproject/whitenoise-system/tests, inifile: pytest.ini
collected 116 items / 115 deselected / 1 selected                                                                                         

sdk/evaluation/test_interface.py .                                                                                                  [100%]

**======== 1 passed, 115 deselected in 3.41s =========** 