### PR TITLE
Eval Interface Class and File Name cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The tools repository for this system allow researchers and analysts to:
 
 * Use SQL dialect to create differentially private results over tabular data stores
 * Host a service to compose queries from heterogeneous differential privacy modules (including non-SQL) against shared privacy budget
-* Perform black-box stochastic testing against differential privacy modules
+* Perform privacy algorithm stochastic testing against differential privacy modules
 
 This differential privacy system is currently aimed at scenarios where the researcher is trusted by the data owner.  Future releases will focus on hardened scenarios where the researcher or analyst is untrusted.  
 
@@ -32,7 +32,7 @@ More information, including information about creating and integrating your own 
 
 ## Evaluator
 
-The stochastic evaluator drives black-box privacy algorithms, checking for privacy violations, accuracy, and bias.  It was inspired by Google's stochastic evaluator, and is implemented in Python.  Future releases will support more intelligent search of query input and data input space.
+The stochastic evaluator drives privacy algorithms, checking for privacy violations, accuracy, and bias.  It was inspired by Google's stochastic evaluator, and is implemented in Python.  Future releases will support more intelligent search of query input and data input space.
 
 Notebooks illustrating the use of the evaluator can be found [here](https://github.com/opendifferentialprivacy/whitenoise-samples/tree/master/evaluator).
 

--- a/sdk/DESCRIPTION.md
+++ b/sdk/DESCRIPTION.md
@@ -4,6 +4,6 @@ The WhiteNoise tools allow researchers and analysts to:
 
 * Use SQL dialect to ceate differentially private results over tabular data stores
 * Host a service to compose queries from heterogeneous differential privacy modules (including non-SQL) against shared privacy budget
-* Perform black-box stochastic testing against differential privacy modules
+* Perform privacy algorithm stochastic testing against differential privacy modules
 
 The WhiteNoise system is currently aimed at scenarios where the researcher is trusted by the data owner.  Future releases will focus on hardened scenarios where the researcher or analyst is untrusted.  

--- a/sdk/opendp/whitenoise/evaluation/evaluator/_base.py
+++ b/sdk/opendp/whitenoise/evaluation/evaluator/_base.py
@@ -1,10 +1,10 @@
-from opendp.whitenoise.evaluation.blackbox._base import BlackBoxPrivacyInterface
+from opendp.whitenoise.evaluation.privacyalgorithm._base import PrivacyAlgorithm
 from opendp.whitenoise.evaluation.params._privacy_params import PrivacyParams
 from opendp.whitenoise.evaluation.params._eval_params import EvaluatorParams
 from opendp.whitenoise.evaluation.metrics._metrics import Metrics
 from abc import ABC, abstractmethod
 
-class EvaluatorInterface(ABC):
+class Evaluator(ABC):
 	"""
 	Interface for various DP implementations to interface with tests available
 	in evaluator. Evaluator tests for various properties of DP implementation
@@ -14,11 +14,11 @@ class EvaluatorInterface(ABC):
 	def evaluate(self, 
 		d1 : object, 
 		d2 : object, 
-		analysis : BlackBoxPrivacyInterface, 
+		analysis : PrivacyAlgorithm, 
 		privacy_params : PrivacyParams, 
 		eval_params : EvaluatorParams) -> Metrics:
 		"""
-		Evaluates properties of black box DP implementations using 
+		Evaluates properties of privacy algorithm DP implementations using 
 			- DP Histogram Test
 			- Accuracy Test
 			- Utility Test

--- a/sdk/opendp/whitenoise/evaluation/explorer/_base.py
+++ b/sdk/opendp/whitenoise/evaluation/explorer/_base.py
@@ -2,7 +2,7 @@ from opendp.whitenoise.evaluation.metrics._metrics import Metrics
 from opendp.whitenoise.evaluation.params._halton_params import HaltonParams
 from abc import ABC, abstractmethod
 
-class ExplorerInterface(ABC):
+class Explorer(ABC):
 	"""
 	DP evaluator can be invoked with various evaluation parameters
 	For example, for a SQL analysis, we can pass various datasets and 

--- a/sdk/opendp/whitenoise/evaluation/learner/_base.py
+++ b/sdk/opendp/whitenoise/evaluation/learner/_base.py
@@ -3,7 +3,7 @@ from opendp.whitenoise.evaluation.params._learner_params import LearnerParams
 from opendp.whitenoise.evaluation.metrics._metrics import Metrics
 from abc import ABC, abstractmethod
 
-class LearnerInterface:
+class Learner(ABC):
 	"""
 	Interface for smarter exploration of datasets and test queries 
 	for finding DP property violations

--- a/sdk/opendp/whitenoise/evaluation/privacyalgorithm/_base.py
+++ b/sdk/opendp/whitenoise/evaluation/privacyalgorithm/_base.py
@@ -3,16 +3,16 @@ from opendp.whitenoise.evaluation.params._eval_params import EvaluatorParams
 from opendp.whitenoise.evaluation.report._report import Report
 from abc import ABC, abstractmethod
 
-class BlackBoxPrivacyInterface(ABC):
+class PrivacyAlgorithm(ABC):
 	"""
-	Interface for every black box differential privacy algorithm to implement
+	Interface for every differential privacy algorithm to implement
 	This shall help define functions that'll allow it to be evaluated whether
 	the DP histogram test passes or not for such implementations. 
 	"""
 	@abstractmethod
 	def prepare(self, analysis : object, privacy_params : PrivacyParams):
 		"""
-		Loads and compiles the specified analysis into a BlackBoxPrivacy instance
+		Loads and compiles the specified analysis into a PrivacyAlgorithm instance
 		An analysis is domain specific and can be any object. For example, 
 		it can be a graph, some sort of script written in any language, or a SQL
 		query. privacy_params are a shared format that is consumed by the evaluator

--- a/sdk/opendp/whitenoise/evaluation/report/_report.py
+++ b/sdk/opendp/whitenoise/evaluation/report/_report.py
@@ -4,7 +4,7 @@ import numpy as np
 class Report:
 	"""
 	Defines the consistent schema of reported fields
-	that aid evaluation of a black box DP implementation
+	that aid evaluation of a DP algorithm implementation
 	* res_df: It is a dataframe that contains repeated 
 	analysis results across dimension and numerical
 	columns. It could be exact or noisy based on the 

--- a/tests/sdk/evaluation/dp_algorithm.py
+++ b/tests/sdk/evaluation/dp_algorithm.py
@@ -1,11 +1,11 @@
 from opendp.whitenoise.evaluation.params._privacy_params import PrivacyParams
 from opendp.whitenoise.evaluation.params._eval_params import EvaluatorParams
 from opendp.whitenoise.evaluation.report._report import Report
-from opendp.whitenoise.evaluation.blackbox._base import BlackBoxPrivacyInterface
+from opendp.whitenoise.evaluation.privacyalgorithm._base import PrivacyAlgorithm
 
-class DPSampleInterface(BlackBoxPrivacyInterface):
+class DPSample(PrivacyAlgorithm):
     """
-    Sample implementation of BlackBoxPrivacy Interface
+    Sample implementation of PrivacyAlgorithm Interface
     that allows for the library to be stochastically tested by
     evaluator. 
     """

--- a/tests/sdk/evaluation/test_interface.py
+++ b/tests/sdk/evaluation/test_interface.py
@@ -3,18 +3,18 @@ test_logger = logging.getLogger("eval-interface-test-logger")
 from opendp.whitenoise.evaluation.params._privacy_params import PrivacyParams
 from opendp.whitenoise.evaluation.params._eval_params import EvaluatorParams
 from opendp.whitenoise.evaluation.report._report import Report
-from opendp.whitenoise.evaluation.blackbox._base import BlackBoxPrivacyInterface
+from opendp.whitenoise.evaluation.privacyalgorithm._base import PrivacyAlgorithm
 from dp_lib import DPSampleLibrary
-from dp_blackbox import DPSampleInterface
+from dp_algorithm import DPSample
 import pandas as pd
 import random
 import pytest
 
-class TestEvalInterface:
-    def test_dp_blackbox(self):
+class TestEval:
+    def test_dp_algorithm(self):
         logging.getLogger().setLevel(logging.DEBUG)
         lib = DPSampleLibrary()
-        dv = DPSampleInterface()
+        dv = DPSample()
         pp = PrivacyParams(epsilon=1.0)
         ev = EvaluatorParams(repeat_count=500)
         df = pd.DataFrame(random.sample(range(1, 1000), 100), columns = ['Usage'])


### PR DESCRIPTION
Changing to PrivacyAlgorithm and remove Interface as we're using ABC. So class need not have that redundancy in the name. 