### PR TITLE
Exact algorithm inclusion in Interfaces

### DIFF
--- a/sdk/opendp/whitenoise/evaluation/benchmarking/_dp_benchmark.py
+++ b/sdk/opendp/whitenoise/evaluation/benchmarking/_dp_benchmark.py
@@ -35,8 +35,10 @@ class DPBenchmarking(Benchmarking):
 				for pp in bp.privacy_params_list:
 					d1 = d1_d2[0]
 					d2 = d1_d2[1]
+					private_algorithm = algorithm[0]
+					exact_algorithm = algorithm[1]
 					dataset_params = DatasetParams(len(d1))
-					bm = BenchmarkMetrics(pa, algorithm, pp, dataset_params, bp.eval_params, Metrics())
-					bm.key_metrics = ev.evaluate(d1, d2, pa, algorithm, pp, bp.eval_params)
+					bm = BenchmarkMetrics(pa, private_algorithm, exact_algorithm, pp, dataset_params, bp.eval_params, Metrics())
+					bm.key_metrics = ev.evaluate(d1, d2, pa, private_algorithm, exact_algorithm, pp, bp.eval_params)
 					benchmark_res.append(bm)
 		return benchmark_res

--- a/sdk/opendp/whitenoise/evaluation/evaluator/_base.py
+++ b/sdk/opendp/whitenoise/evaluation/evaluator/_base.py
@@ -16,6 +16,7 @@ class Evaluator(ABC):
 		d2 : object, 
 		pa : PrivacyAlgorithm,
 		algorithm : object, 
+		actual : object,
 		privacy_params : PrivacyParams, 
 		eval_params : EvaluatorParams) -> {str : Metrics}:
 		"""
@@ -27,6 +28,7 @@ class Evaluator(ABC):
 		
 		d1 and d2 are neighboring datasets
 		algorithm is the DP implementation object
+		actual is the non-private implementation object
 		Returns a metrics object
 		"""
 		pass

--- a/sdk/opendp/whitenoise/evaluation/evaluator/_dp_evaluator.py
+++ b/sdk/opendp/whitenoise/evaluation/evaluator/_dp_evaluator.py
@@ -177,6 +177,7 @@ class DPEvaluator(Evaluator):
 		d2 : object, 
 		pa : PrivacyAlgorithm, 
         algorithm : object,
+        actual : object,
 		pp : PrivacyParams, 
 		ep : EvaluatorParams) -> {str : Metrics}:
         """
@@ -193,7 +194,7 @@ class DPEvaluator(Evaluator):
         pa.prepare(algorithm, pp, ep)
         d1report = pa.release(d1)
         d2report = pa.release(d2)
-        d1actual = pa.release(d1, actual=True)
+        d1actual = pa.release(d1, actual=actual)
         key_metrics = {}
 
         for key in d1report.res.keys():

--- a/sdk/opendp/whitenoise/evaluation/metrics/_benchmark_metrics.py
+++ b/sdk/opendp/whitenoise/evaluation/metrics/_benchmark_metrics.py
@@ -12,6 +12,7 @@ class BenchmarkMetrics:
 	def __init__(self, 
 			pa : PrivacyAlgorithm,
 			algorithm : object,
+			exact_algorithm : object,
 			privacy_params : PrivacyParams,
 			dataset_params : DatasetParams,
 			eval_params : EvaluatorParams, 
@@ -19,6 +20,7 @@ class BenchmarkMetrics:
 		):
 		self.pa = pa
 		self.algorithm = algorithm
+		self.exact_algorithm = algorithm
 		self.privacy_params = privacy_params
 		self.dataset_params = dataset_params
 		self.eval_params = eval_params

--- a/sdk/opendp/whitenoise/evaluation/params/_benchmark_params.py
+++ b/sdk/opendp/whitenoise/evaluation/params/_benchmark_params.py
@@ -9,7 +9,7 @@ class BenchmarkParams:
     Algorithms are the list of DP algorithms that need to be benchmarked
 	"""
 	def __init__(self,
-			pa_algorithms : {PrivacyAlgorithm : object},
+			pa_algorithms : {PrivacyAlgorithm : [object, object]},
 			privacy_params_list : [PrivacyParams],
 			d1_d2_list : [[object, object]],
 			eval_params : EvaluatorParams

--- a/sdk/opendp/whitenoise/evaluation/privacyalgorithm/_base.py
+++ b/sdk/opendp/whitenoise/evaluation/privacyalgorithm/_base.py
@@ -20,7 +20,7 @@ class PrivacyAlgorithm(ABC):
 		pass
 	
 	@abstractmethod
-	def release(self, dataset : object, actual = False) -> Report:
+	def release(self, dataset : object, actual = None) -> Report:
 		"""
 		Return a single report using the previously loaded algorithm and 
 		privacy_params applied on loaded dataset. The report must follow 

--- a/tests/sdk/evaluation/dp_algorithm.py
+++ b/tests/sdk/evaluation/dp_algorithm.py
@@ -19,10 +19,10 @@ class DPSample(PrivacyAlgorithm):
         self.privacy_params = privacy_params
         self.eval_params = eval_params
 
-    def release(self, dataset: object, actual = False) -> Report:
+    def release(self, dataset: object, actual = None) -> Report:
         if(not actual):
             noisy_res = self.algorithm(dataset, self.privacy_params, self.eval_params)
             return Report(noisy_res)
         else:
-            actual_res = {"__key__" : len(dataset)}
+            actual_res = {"__key__" : actual(dataset)}
             return Report(actual_res)

--- a/tests/sdk/evaluation/dp_core.py
+++ b/tests/sdk/evaluation/dp_core.py
@@ -20,7 +20,7 @@ class DPCore(PrivacyAlgorithm):
         self.privacy_params = privacy_params
         self.eval_params = eval_params
 
-    def release(self, dataset: object, actual = False) -> Report:
+    def release(self, dataset: object, actual = None) -> Report:
         """
         Releases report according to the OpenDP Core applying 
         functions on the dataset or return the actual report
@@ -44,5 +44,5 @@ class DPCore(PrivacyAlgorithm):
                     noisy_res["__key__"].append(agg.value)
             return Report(noisy_res)
         else:
-            actual_res = {"__key__" : sum(dataset) / len(dataset)}
+            actual_res = {"__key__" : actual(dataset)}
             return Report(actual_res)

--- a/tests/sdk/evaluation/dp_multikey.py
+++ b/tests/sdk/evaluation/dp_multikey.py
@@ -21,7 +21,7 @@ class DPMultiKey(PrivacyAlgorithm):
         self.privacy_params = privacy_params
         self.eval_params = eval_params
 
-    def release(self, dataset: object, actual = False) -> Report:
+    def release(self, dataset: object, actual = None) -> Report:
         """
         Dataset is Pandas Dataframe with multiple columns and we need to sum
         elements in each column and assign a key (column name) for each column.  
@@ -35,5 +35,5 @@ class DPMultiKey(PrivacyAlgorithm):
         else:
             actual_res = {}
             for col in list(dataset):
-                actual_res[col] = sum(dataset[col].tolist())
+                actual_res[col] = actual(dataset[col].tolist())
             return Report(actual_res)

--- a/tests/sdk/evaluation/dp_singleton_query.py
+++ b/tests/sdk/evaluation/dp_singleton_query.py
@@ -21,7 +21,7 @@ class DPSingletonQuery(PrivacyAlgorithm):
         self.privacy_params = privacy_params
         self.eval_params = eval_params
 
-    def release(self, dataset: object, actual = False) -> Report:
+    def release(self, dataset: object, actual = None) -> Report:
         """
         Dataset is a collection of [Dataset Metadata, PandasReader]
         Releases response to SQL query based on the number of repetitions
@@ -40,5 +40,5 @@ class DPSingletonQuery(PrivacyAlgorithm):
             return Report({"__key__" : noisy_values})
         else:
             reader = dataset[1]
-            exact = reader.execute_typed(self.algorithm).rows()[1:][0][0]
+            exact = reader.execute_typed(actual).rows()[1:][0][0]
             return Report({"__key__" : exact})

--- a/tests/sdk/evaluation/test_core.py
+++ b/tests/sdk/evaluation/test_core.py
@@ -10,6 +10,7 @@ from opendp.whitenoise.evaluation.benchmarking._dp_benchmark import DPBenchmarki
 from opendp.whitenoise.evaluation.metrics._metrics import Metrics
 import random
 import pytest
+from statistics import mean
 
 class TestCore:
     @pytest.mark.skip(reason="Skipping in System build as it uses OpenDP Core")
@@ -40,7 +41,7 @@ class TestCore:
         d2.remove(drop_elem)
         # Call evaluate
         eval = DPEvaluator()
-        key_metrics = eval.evaluate(d1, d2, pa, wn.dp_mean, pp, ev)
+        key_metrics = eval.evaluate(d1, d2, pa, wn.dp_mean, mean, pp, ev)
         # After evaluation, it should return True and distance metrics should be non-zero
         for key, metrics in key_metrics.items():
             assert(metrics.dp_res == True)
@@ -76,7 +77,7 @@ class TestCore:
         d2.remove(drop_elem)
         benchmarking = DPBenchmarking()
         # Preparing benchmarking params
-        pa_algorithms = {pa : wn.dp_mean}
+        pa_algorithms = {pa : [wn.dp_mean, mean]}
         privacy_params_list = []
         for epsilon in epsilon_list:
             pp = PrivacyParams()

--- a/tests/sdk/evaluation/test_interface.py
+++ b/tests/sdk/evaluation/test_interface.py
@@ -39,7 +39,7 @@ class TestEval:
         assert(len(report.res[firstkey]) == ev.repeat_count)
 
         # Test non-DP i.e. actual response from interface should be a single numeric return
-        report = dv.release(df, actual=True)
+        report = dv.release(df, actual=len)
         test_logger.debug("Actual count response: "  + str(report.res[firstkey]))
 
         assert(isinstance(report.res[firstkey], (int, float)))
@@ -66,7 +66,7 @@ class TestEval:
         d2 = d1.drop(drop_idx)
         # Call evaluate
         eval = DPEvaluator()
-        key_metrics = eval.evaluate(d1, d2, pa, lib.dp_count, pp, ev)
+        key_metrics = eval.evaluate(d1, d2, pa, lib.dp_count, len, pp, ev)
         # After evaluation, it should return True and distance metrics should be non-zero
         for key, metrics in key_metrics.items():
             assert(metrics.dp_res == True)
@@ -96,7 +96,7 @@ class TestEval:
         d2 = d1.drop(drop_idx)
         benchmarking = DPBenchmarking()
         # Preparing benchmarking params
-        pa_algorithms = {pa : lib.dp_count}
+        pa_algorithms = {pa : [lib.dp_count, len]}
         privacy_params_list = []
         for epsilon in epsilon_list:
             pp = PrivacyParams()
@@ -137,7 +137,7 @@ class TestEval:
         d2 = d1.drop(drop_idx)
         # Call evaluate
         eval = DPEvaluator()
-        key_metrics = eval.evaluate(d1, d2, pa, lib.dp_sum, pp, ev)
+        key_metrics = eval.evaluate(d1, d2, pa, lib.dp_sum, sum, pp, ev)
         # After evaluation, it should return True and distance metrics should be non-zero
         for key, metrics in key_metrics.items():
             assert(metrics.dp_res == True)

--- a/tests/sdk/evaluation/test_sql.py
+++ b/tests/sdk/evaluation/test_sql.py
@@ -79,7 +79,7 @@ class TestSql:
 
         # Call evaluate
         eval = DPEvaluator()
-        key_metrics = eval.evaluate([d1_metadata, d1], [d2_metadata, d2], pa, query, pp, ev)
+        key_metrics = eval.evaluate([d1_metadata, d1], [d2_metadata, d2], pa, query, query, pp, ev)
         # After evaluation, it should return True and distance metrics should be non-zero
         for key, metrics in key_metrics.items():
             assert(metrics.dp_res == True)


### PR DESCRIPTION
The user should be able to provide both private and exact (non-private) algorithm to compute accuracy and bias metrics. In PrivacyAlgorithm interface, actual is set to None by default (instead of False earlier). If actual is not None, the release method in PrivacyAlgorithm interface returns exact response. 

(py38) ankit@ANKIT-DELL:/mnt/c/Users/ankitsri/source/code/privacytoolsproject/whitenoise-system/tests/sdk/evaluation$ pytest -k "test_interface" -s
================ test session starts ==================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /mnt/c/Users/ankitsri/source/code/privacytoolsproject/whitenoise-system/tests, configfile: pytest.ini
collected 18 items / 11 deselected / 7 selected

test_core.py ..
test_interface.py ....
test_sql.py .

=============== 7 passed, 11 deselected in 15.81s ===========================================