### PR TITLE
Wrong Classname for PytorchSynthesizer

### DIFF
--- a/tests/sdk/synthesizers/test_pategan.py
+++ b/tests/sdk/synthesizers/test_pategan.py
@@ -28,7 +28,7 @@ df = pd.read_csv(csv_path)
 @pytest.mark.torch
 class TestDPGAN:
     def setup(self):
-        self.pategan = PytorchSynthesizer(PATEGAN(), GeneralTransformer())
+        self.pategan = PytorchDPSynthesizer(PATEGAN(), GeneralTransformer())
 
     def test_fit(self):
         self.pategan.fit(df)


### PR DESCRIPTION
The test fails at line 31 because of the wrong classname.
Other classes implement the correct one.